### PR TITLE
Feature: Option To Show Only Countries In Dialog

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,6 @@ class _MyAppState extends State<MyApp> {
             body: new Center(
               child: new CountryCodePicker(
                   onChanged: print,
-                  showCountryOnly: true,
                   // Initial selection and favorite can be one of code ('IT') OR dial_code('+39')
                   initialSelection: 'IT',
                   favorite: ['+39', 'FR']),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,6 +24,7 @@ class _MyAppState extends State<MyApp> {
             body: new Center(
               child: new CountryCodePicker(
                   onChanged: print,
+                  showCountryOnly: true,
                   // Initial selection and favorite can be one of code ('IT') OR dial_code('+39')
                   initialSelection: 'IT',
                   favorite: ['+39', 'FR']),

--- a/lib/country_code.dart
+++ b/lib/country_code.dart
@@ -23,4 +23,6 @@ class CountryCode {
   String toString() => "$dialCode";
 
   String toLongString() => "$dialCode $name";
+
+  String toCountryStringOnly() => '$name';
 }

--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -1,3 +1,4 @@
+
 library country_code_picker;
 
 import 'package:country_code_picker/country_code.dart';
@@ -13,6 +14,7 @@ class CountryCodePicker extends StatefulWidget {
   final List<String> favorite;
   final TextStyle textStyle;
   final EdgeInsetsGeometry padding;
+  final bool showCountryOnly;
 
   CountryCodePicker({
     this.onChanged,
@@ -20,6 +22,7 @@ class CountryCodePicker extends StatefulWidget {
     this.favorite = const [],
     this.textStyle,
     this.padding = const EdgeInsets.all(0.0),
+    this.showCountryOnly = false,
   });
 
   @override
@@ -103,7 +106,7 @@ class _CountryCodePickerState extends State<CountryCodePicker> {
   void _showSelectionDialog() {
     showDialog(
       context: context,
-      builder: (_) => new SelectionDialog(elements, favoriteElements),
+      builder: (_) => new SelectionDialog(elements, favoriteElements, showCountryOnly: widget.showCountryOnly),
     ).then((e) {
       if (e != null) {
         setState(() {

--- a/lib/selection_dialog.dart
+++ b/lib/selection_dialog.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart';
 /// selection dialog used for selection of the country code
 class SelectionDialog extends StatefulWidget {
   final List<CountryCode> elements;
+  bool showCountryOnly;
 
   /// elements passed as favorite
   final List<CountryCode> favoriteElements;
 
-  SelectionDialog(this.elements, this.favoriteElements);
+  SelectionDialog(this.elements, this.favoriteElements,
+      {this.showCountryOnly});
 
   @override
   State<StatefulWidget> createState() => new _SelectionDialogState();
@@ -54,7 +56,9 @@ class _SelectionDialogState extends State<SelectionDialog> {
                                   Flexible(
                                     fit: FlexFit.tight,
                                     child: new Text(
-                                      f.toLongString(),
+                                      widget.showCountryOnly
+                                          ? f.toCountryStringOnly()
+                                          : f.toLongString(),
                                       overflow: TextOverflow.fade,
                                     ),
                                   ),
@@ -87,7 +91,9 @@ class _SelectionDialogState extends State<SelectionDialog> {
                       Flexible(
                         fit: FlexFit.tight,
                         child: Text(
-                          e.toLongString(),
+                          widget.showCountryOnly
+                              ? e.toCountryStringOnly()
+                              : e.toLongString(),
                           overflow: TextOverflow.fade,
                         ),
                       ),


### PR DESCRIPTION
This feature adds the option to show only countries in the dialog for use cases that only need the country name and flag.

Here is a screenshot of it.
![20190314_235612_rmscr 1](https://user-images.githubusercontent.com/19398044/54397044-545e4580-46b5-11e9-8e4a-9bf66d26e021.jpg)

Usage:
It is an optional named argument in the CountryCodePicker widget.

```
CountryCodePicker(
                  onChanged: print,
                  showCountryOnly: true,
                  // Initial selection and favorite can be one of code ('IT') OR dial_code('+39')
                  initialSelection: 'IT',
                  favorite: ['+39', 'FR']),

```