### PR TITLE
Add second Puerto Rico phone code

### DIFF
--- a/lib/country_codes.dart
+++ b/lib/country_codes.dart
@@ -190,6 +190,7 @@ List<Map> codes = [
   {"name": "Polska", "code": "PL", "dial_code": "+48"},
   {"name": "Portugal", "code": "PT", "dial_code": "+351"},
   {"name": "Puerto Rico", "code": "PR", "dial_code": "+1939"},
+  {"name": "Puerto Rico", "code": "PR", "dial_code": "+1787"},
   {"name": "قطر", "code": "QA", "dial_code": "+974"},
   {"name": "România", "code": "RO", "dial_code": "+40"},
   {"name": "Россия", "code": "RU", "dial_code": "+7"},


### PR DESCRIPTION
Puerto Rico has 2 phone codes (https://countrycode.org/puertorico) - so we need to add second one