### PR TITLE
Make modal_bottom_sheet uses dynamic versioning

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.2.2  <3.0.0"
 
 dependencies:
-  modal_bottom_sheet: 0.2.0
+  modal_bottom_sheet: ^0.2.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
with current approach, if we use some other version of modal_bottom_sheet in our projects, we face:
```
Because country_code_picker 1.5.0 depends on modal_bottom_sheet 0.2.0 and no versions of country_code_picker match >1.5.0 <2.0.0, country_code_picker ^1.5.0 requires modal_bottom_sheet 0.2.0.

So, because my_project_flutter depends on both country_code_picker ^1.5.0 and modal_bottom_sheet ^0.2.2, version solving failed.
pub get failed (1; So, because my_project_flutter depends on both country_code_picker ^1.5.0 and modal_bottom_sheet ^0.2.2, version solving failed.)
```

I've changed the versioning of the modal_bottom_sheet to be dynamic, thus not limiting other projects to be forced to use a version specified in this library