### PR TITLE
Adds background color to selection dialog

### DIFF
--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -37,6 +37,9 @@ class CountryCodePicker extends StatefulWidget {
   /// the size of the selection dialog
   final Size dialogSize;
 
+  /// Background color of selection dialog
+  final Color dialogBackgroundColor;
+
   /// used to customize the country list
   final List<String> countryFilter;
 
@@ -97,6 +100,7 @@ class CountryCodePicker extends StatefulWidget {
     this.countryFilter,
     this.hideSearch = false,
     this.dialogSize,
+    this.dialogBackgroundColor,
     this.closeIcon = const Icon(Icons.close),
     Key key,
   }) : super(key: key);
@@ -260,6 +264,7 @@ class CountryCodePickerState extends State<CountryCodePicker> {
               : widget.showFlag,
           flagWidth: widget.flagWidth,
           size: widget.dialogSize,
+          backgroundColor: widget.dialogBackgroundColor,
           hideSearch: widget.hideSearch,
           closeIcon: widget.closeIcon,
         ),

--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -265,6 +265,7 @@ class CountryCodePickerState extends State<CountryCodePicker> {
           flagWidth: widget.flagWidth,
           size: widget.dialogSize,
           backgroundColor: widget.dialogBackgroundColor,
+          barrierColor: widget.barrierColor,
           hideSearch: widget.hideSearch,
           closeIcon: widget.closeIcon,
         ),

--- a/lib/selection_dialog.dart
+++ b/lib/selection_dialog.dart
@@ -19,6 +19,9 @@ class SelectionDialog extends StatefulWidget {
   /// Background color of SelectionDialog
   final Color backgroundColor;
 
+  /// Boxshaow color of SelectionDialog that matches CountryCodePicker barrier color
+  final Color barrierColor;
+
   /// elements passed as favorite
   final List<CountryCode> favoriteElements;
 
@@ -36,6 +39,7 @@ class SelectionDialog extends StatefulWidget {
     this.flagWidth = 32,
     this.size,
     this.backgroundColor,
+    this.barrierColor,
     this.hideSearch = false,
     this.closeIcon,
   })  : assert(searchDecoration != null, 'searchDecoration must not be null!'),
@@ -66,7 +70,7 @@ class _SelectionDialogState extends State<SelectionDialog> {
                 borderRadius: BorderRadius.all(Radius.circular(25.0)),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.grey.withOpacity(1),
+                    color: widget.barrierColor ?? Colors.grey.withOpacity(1),
                     spreadRadius: 5,
                     blurRadius: 7,
                     offset: Offset(0, 3), // changes position of shadow

--- a/lib/selection_dialog.dart
+++ b/lib/selection_dialog.dart
@@ -16,6 +16,9 @@ class SelectionDialog extends StatefulWidget {
   final bool hideSearch;
   final Icon closeIcon;
 
+  /// Background color of SelectionDialog
+  final Color backgroundColor;
+
   /// elements passed as favorite
   final List<CountryCode> favoriteElements;
 
@@ -32,6 +35,7 @@ class SelectionDialog extends StatefulWidget {
     this.showFlag,
     this.flagWidth = 32,
     this.size,
+    this.backgroundColor,
     this.hideSearch = false,
     this.closeIcon,
   })  : assert(searchDecoration != null, 'searchDecoration must not be null!'),
@@ -58,7 +62,7 @@ class _SelectionDialogState extends State<SelectionDialog> {
               widget.size?.height ?? MediaQuery.of(context).size.height * 0.85,
           decoration: widget.boxDecoration ??
               BoxDecoration(
-                color: Colors.white,
+                color: widget.backgroundColor ?? Colors.white,
                 borderRadius: BorderRadius.all(Radius.circular(25.0)),
                 boxShadow: [
                   BoxShadow(


### PR DESCRIPTION
Both barrierColor and backgroundColor for the CountryCodePicker seem to update the background of the selection dialog only as of version 1.6.2.

This adds the ability to assign a background color to the selection dialog itself so it can be updated accordingly, such as dark and light mode.