### PR TITLE
Change modal_bottom_sheet fro 1.0.1-dev to 1.0.0+1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  modal_bottom_sheet: ^1.0.1-dev
+  modal_bottom_sheet: ^1.0.0+1
 
 flutter:
   assets:


### PR DESCRIPTION
Hello, great plugin.

Version 1.0.1-dev of _modal_bottom_sheet_ still has the _shadowThemeOnly_ parameter, which causes build errors, which means that CountryCodePicker cannot be built with the latest version of Flutter. Using 1.0.0+1 fixes this; in fact version 1.0.0 is actually more recent than 1.0.1-dev, the developer made a mistake during versioning. You can read more [here](https://github.com/jamesblasco/modal_bottom_sheet/issues/117).